### PR TITLE
chore: skip GitHub release creation for pre-release versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,6 +51,7 @@ jobs:
         run: npm publish --provenance --access public --tag ${{ steps.release-info.outputs.npm_tag }}
 
       - name: Create GitHub Release
+        if: steps.release-info.outputs.is_prerelease == 'false'
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true


### PR DESCRIPTION
Skip creating a GitHub Release when publishing a pre-release (`-next-*`) version to npm. This prevents follower notifications for pre-release tags.