### PR TITLE
release: v0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ctrf",
-  "version": "0.2.0-next-0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ctrf",
-      "version": "0.2.0-next-0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ctrf",
-  "version": "0.2.0-next-1",
+  "version": "0.2.0",
   "description": "CTRF reference implementation in TypeScript for creating and validating CTRF documents.",
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
## v0.2.0

Stable release of dual ESM + CJS output.

### Changes since v0.1.0

- **Dual ESM + CJS build** via `tsup` — replaces `tsc` build
  - `dist/index.js` (ESM) + `dist/index.cjs` (CJS)
  - `dist/index.d.ts` + `dist/index.d.cts` type declarations
  - `exports` map with `import` / `require` conditions
- `main` field updated to `dist/index.cjs` for legacy compatibility
- `module` field added for ESM bundler resolution
- Removed `typescript` from runtime `dependencies`
- CI: skip GitHub release creation for pre-release tags